### PR TITLE
chore: Use merge group trigger for merge queue CI

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,6 +1,7 @@
 name: Build Image
 
 on:
+  merge_group:
   pull_request_target:
     types: [opened, edited, synchronize, reopened, ready_for_review]
     branches:

--- a/.github/workflows/pr-all-checks-passed.yml
+++ b/.github/workflows/pr-all-checks-passed.yml
@@ -1,5 +1,6 @@
 name: All Checks passed
 on:
+  merge_group:
   pull_request:
     types:
       [

--- a/.github/workflows/pr-code-checks.yml
+++ b/.github/workflows/pr-code-checks.yml
@@ -1,6 +1,7 @@
 name: PR Code Checks
 
 on:
+  merge_group:
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/pr-docu-checks.yml
+++ b/.github/workflows/pr-docu-checks.yml
@@ -1,6 +1,7 @@
 name: PR Docu Checks
 
 on:
+  merge_group:
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/pr-github-checks.yml
+++ b/.github/workflows/pr-github-checks.yml
@@ -1,6 +1,7 @@
 name: PR Github Checks
 
 on:
+  merge_group:
   pull_request_target:
     branches:
       - "main"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add the `merge_group` trigger to run CI in merge queues

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
