### PR TITLE
chore: Remove merge_group trigger for some workflows

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,6 +17,7 @@ jobs:
       name: directory-size-exporter
       dockerfile: ./Dockerfile
       context: .
+      tags: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
 
   list-images:
     needs: build-image

--- a/.github/workflows/pr-docu-checks.yml
+++ b/.github/workflows/pr-docu-checks.yml
@@ -1,7 +1,6 @@
 name: PR Docu Checks
 
 on:
-  merge_group:
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/pr-github-checks.yml
+++ b/.github/workflows/pr-github-checks.yml
@@ -1,7 +1,6 @@
 name: PR Github Checks
 
 on:
-  merge_group:
   pull_request_target:
     branches:
       - "main"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Remove merge_group for some workflows which are not needed for merge queues (GitHub checks, Docu checks)

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
