### PR TITLE
chore: configure permissions for all gh actions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,7 +17,6 @@ jobs:
   build-image:
     permissions:
       id-token: write
-      contents: read
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: directory-size-exporter

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,5 +1,8 @@
 name: Build Image
 
+permissions:
+  contents: read
+
 on:
   merge_group:
   pull_request_target:
@@ -10,12 +13,11 @@ on:
     branches:
       - "main"
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
   build-image:
+    permissions:
+      id-token: write
+      contents: read
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: directory-size-exporter

--- a/.github/workflows/periodic-github-checks.yaml
+++ b/.github/workflows/periodic-github-checks.yaml
@@ -1,5 +1,8 @@
 name: 'Periodic Github Checks'
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 0 * * *'  # Runs daily at midnight
@@ -9,7 +12,7 @@ jobs:
   stale-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-stale: 60
           days-before-close: 7

--- a/.github/workflows/pr-all-checks-passed.yml
+++ b/.github/workflows/pr-all-checks-passed.yml
@@ -16,12 +16,12 @@ on:
         labeled,
         milestoned,
       ]
+
 jobs:
   all-checks:
     runs-on: ubuntu-latest
     permissions:
       checks: read
-      contents: read
     steps:
       - uses: wechuli/allcheckspassed@e22f45a4f25f4cf821d1273705ac233355400db1 # v1.2.0
         with:

--- a/.github/workflows/pr-all-checks-passed.yml
+++ b/.github/workflows/pr-all-checks-passed.yml
@@ -1,4 +1,8 @@
 name: All Checks passed
+
+permissions:
+  contents: read
+
 on:
   merge_group:
   pull_request:

--- a/.github/workflows/pr-code-checks.yml
+++ b/.github/workflows/pr-code-checks.yml
@@ -1,5 +1,8 @@
 name: PR Code Checks
 
+permissions:
+  contents: read
+
 on:
   merge_group:
   pull_request:
@@ -16,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Golang
         uses: "./.github/template/setup-golang"
@@ -28,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Golang
         uses: "./.github/template/setup-golang"
@@ -39,7 +42,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Fetch gitleaks ${{ env.GITLEAKS_VERSION }}

--- a/.github/workflows/pr-docu-checks.yml
+++ b/.github/workflows/pr-docu-checks.yml
@@ -1,5 +1,8 @@
 name: PR Docu Checks
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:
@@ -12,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
       - name: Install md-check-link

--- a/.github/workflows/pr-github-checks.yml
+++ b/.github/workflows/pr-github-checks.yml
@@ -1,5 +1,8 @@
 name: PR Github Checks
 
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     branches:
@@ -23,14 +26,14 @@ env:
   TITLE: ${{ github.event.pull_request.title }}
   GH_HOST: github.com
 
-permissions: write-all
-
 jobs:
   pr-label-check:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Add kind label based on PR title prefix
         if: always()


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- CodeQL reports that default permissions are to corse-grained
-> added most restrictive permissions for all jobs
-> enabled more powerful permissions on the jobs directly

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
