### PR TITLE
chore: fix permissions for all gh actions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,6 +17,7 @@ jobs:
   build-image:
     permissions:
       id-token: write
+      contents: read
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: directory-size-exporter

--- a/.github/workflows/pr-all-checks-passed.yml
+++ b/.github/workflows/pr-all-checks-passed.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: read
+      contents: read
     steps:
       - uses: wechuli/allcheckspassed@e22f45a4f25f4cf821d1273705ac233355400db1 # v1.2.0
         with:

--- a/.github/workflows/pr-github-checks.yml
+++ b/.github/workflows/pr-github-checks.yml
@@ -30,6 +30,7 @@ jobs:
   pr-label-check:
     permissions:
       pull-requests: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Repeat default permission in overwrites as they are not additive

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/directory-size-exporter/pull/148

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
