### PR TITLE
chore: remove build-engine buildx

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -24,7 +24,6 @@ jobs:
       dockerfile: ./Dockerfile
       context: .
       tags: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
-      build-engine: buildx
       platforms: "linux/amd64,linux/arm64"
 
   list-images:


### PR DESCRIPTION
This PR removes the deprecated `build-engine: buildx` entry from workflows.